### PR TITLE
fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project contains the source code examples for the blog/book "The Maker's Gu
 The code examples can be imported into the Silicon Labs Simpliciy Studio IDE and compiled and downloaded to the Wonder Gecko Starter Kit.
 
 Learn more about the blog here:
-http://www.silabs.com/products/mcu/Pages/makers-guide-to-the-iot.aspx
+https://www.silabs.com/products/mcu/32-bit/makers-guide-to-the-iot
 
 More about David Lynch here:
 http://sabertron.com/the-sabertron-team/


### PR DESCRIPTION
This commit update the link to "The Maker's Guide to the IoT".